### PR TITLE
Fixed Single/Multiple Vaccine Uploads;

### DIFF
--- a/index.js
+++ b/index.js
@@ -782,7 +782,15 @@ app.post('/addingDog', upload.array('dogUpload', 6), async (req, res) => {
         // Loop through all files and upload PDFs to Google Cloud Storage
         let v = 0;
         for (let i = 0; i < req.files.length; i++) {
-            let vaccineType = req.body.vaccineCheck[v]; // We put v here because the first iteration (i) might be the profile photo image
+            let vaccineType;
+            
+            // Check if you have one or multiple vaccines to upload
+            if (Array.isArray(req.body.vaccineCheck)) {
+                vaccineType = req.body.vaccineCheck[v]; // We put v here because the first iteration (i) might be the profile photo image
+            } else {
+                vaccineType = req.body.vaccineCheck;
+            }
+            
             let filename = req.files[i].mimetype;
             filename = filename.split('/');
             let fileType = filename[0];


### PR DESCRIPTION
Fixed an issue where, if you upload only one vaccine pdf, it would save the file in the Google Cloud Storage as only the first letter of the vaccination type. (For example, rabies would be Last_Dog_r.pdf). This was caused by the name of the vaccination type being split into a list, with the first letter being located at the first position of the array, rather than the whole string itself. (This wasn't an issue with uploading multiple files, because the first position in the array was occupied with the full string of the first vaccine. (Intended behaviour.) This is what happens when I don't test my code as thouroughly as I'd like to, I guess.)

TL;DR - Now you can upload one, or multiple different vaccine DOGuments (documents, haha). A small but crucial change... Please accept my pull request we need to go live in two hours 🥺🙏